### PR TITLE
Remove chef dependency

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,8 @@
 driver:
   name: docker
-  use_sudo: <% if ENV["TRAVIS"] then true else false end %>
+  chef_bootstrap_url: nil
   use_cache: true
+  use_sudo: <% if ENV["TRAVIS"] then true else false end %>
   #kitchen-docker can't parse docker 1.12 build -q output
   #https://github.com/test-kitchen/kitchen-docker/issues/225
   #build_options: "-q"
@@ -32,8 +33,12 @@ provisioner:
 # Will be filled out in .kitchen.local.yml
 suites: []
 
-#verifier:
-# TODO
-#  name: serverspec
-#  additional_install_command: mkdir -p /tmp/kitchen
-#  name: shell
+verifier:
+  name: serverspec
+  additional_install_command: mkdir -p /tmp/kitchen
+  # Avoid "sudo: gem: command not found"
+  sudo_command: "sudo -E"
+  # test_serverspec_installed: false
+  default_pattern: true
+  # false to run serverspec on local machine, true to run remotely
+  remote_exec: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -36,6 +36,7 @@ suites: []
 verifier:
   name: serverspec
   additional_install_command: mkdir -p /tmp/kitchen
+  sudo: false
   # Avoid "sudo: gem: command not found"
   sudo_command: "sudo -E"
   # test_serverspec_installed: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ rvm:
   - 2.2
   - 2.1
   - 2.0
-  - 1.9.3
+# Not supported by net-ssh >= 3, which in turn is required by
+# kitchen-verifier-serverspec
+#  - 1.9.3
 
 sudo: required
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'net-ssh', '2.9.4'
   gem 'kitchen-ansiblepush', '!= 0.5.2'
   # kitchen-docker 2.5.0 is broken, see
   # https://github.com/ahelal/kitchen-ansiblepush/issues/31
@@ -10,9 +9,11 @@ group :development do
   # including kitchen-sync with sftp does not actually help -- builds
   # were around 31--34 minutes on travis CI with and without SFTP
   # gem 'kitchen-sync', '2.1.0'
-  #gem 'kitchen-verifier-serverspec',
-  #  :ref => 'ef120567c8ade49c373bd4ac7e4a755408109104'
+  # Blacklist 0.6.2 due to
+  # https://github.com/neillturner/kitchen-verifier-serverspec/pull/20
+  gem 'kitchen-verifier-serverspec', '!= 0.5.2', '!= 0.6.2'
   #gem 'kitchen-verifier-shell'
+  gem 'net-ssh'
   #gem 'serverspec'
   gem 'test-kitchen'
   gem 'thor', '!= 0.19.2'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,10 @@ group :development do
   # gem 'kitchen-sync', '2.1.0'
   # Blacklist 0.6.2 due to
   # https://github.com/neillturner/kitchen-verifier-serverspec/pull/20
-  gem 'kitchen-verifier-serverspec', '!= 0.5.2', '!= 0.6.2'
+  #gem 'kitchen-verifier-serverspec', '!= 0.5.2', '!= 0.6.2'
+  gem 'kitchen-verifier-serverspec',
+    :git => 'https://github.com/wtanaka/kitchen-verifier-serverspec.git',
+    :ref => '6246275109f296feabb9d389fc4dacd87e4208ca'
   #gem 'kitchen-verifier-shell'
   gem 'net-ssh'
   #gem 'serverspec'

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
   #gem 'kitchen-verifier-serverspec', '!= 0.5.2', '!= 0.6.2'
   gem 'kitchen-verifier-serverspec',
     :git => 'https://github.com/wtanaka/kitchen-verifier-serverspec.git',
-    :ref => '6246275109f296feabb9d389fc4dacd87e4208ca'
+    :ref => '9474ede292c21c91222e142207c0db81f044bd83'
   #gem 'kitchen-verifier-shell'
   gem 'net-ssh'
   #gem 'serverspec'

--- a/run.sh
+++ b/run.sh
@@ -70,6 +70,9 @@ export ROLE_UNDER_TEST
 # Inlined from _functions.sh
 ROLE_DIR="."
 ROLE_TESTER_DIR="$PROJECT"-"$BRANCH"
+
+make -s -C "$PROJECT"-"$BRANCH" rewrite
+
 if [ -d "$ROLE_DIR"/test/integration/default/serverspec ]; then
    (cd $ROLE_TESTER_DIR; bundle exec kitchen diagnose |
       grep '^[ ]*suite_name: ' | cut -d: -f2 | cut -c2- | uniq) |


### PR DESCRIPTION
This patch uses kitchen-verifier-serverspec which transitively
requires Ruby >= 2, so this patch drops support for Ruby 1.x