### PR TITLE
Ansible 1.3 Compatibility: Remove ansible.cfg; Hardcode role name in playbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,11 +23,6 @@ provisioner:
   playbook: kitchen-playbook.yml
   support_older_version: true
   verbose: <%= ENV["ANSIBLE_VERBOSE"] %>
-  extra_vars:
-    # We will override this in .kitchen.local.yml so that we can
-    # manually run kitchen commands later without having to set this
-    # environment variable
-    role_under_test: <%= ENV["ROLE_UNDER_TEST"] %>
 
 # Will be filled out in .kitchen.local.yml
 suites: []

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-roles_path = ../..

--- a/fake-role/defaults/main.yml
+++ b/fake-role/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for fake-role
+# Ansible 1.3 crashes without this
+workaround_ansible_issue_4129: True

--- a/fake-role/tasks/main.yml
+++ b/fake-role/tasks/main.yml
@@ -33,4 +33,8 @@
 
 - name: make file
   lineinfile: >
-    create=yes dest=/tmp/fakerole.txt state=present line=fakerole
+    create=yes
+    dest=/tmp/fakerole.txt
+    state=present
+    line=fakerole
+    regexp='^fakerole$'

--- a/kitchen-playbook.yml
+++ b/kitchen-playbook.yml
@@ -1,6 +1,0 @@
----
-- include: playbook-compat.yml
-- hosts: all
-  roles:
-  - role: "{{role_under_test}}"
-    is_integration_test: True

--- a/update_kitchen_yml.py
+++ b/update_kitchen_yml.py
@@ -50,17 +50,6 @@ def platforms(os_versions):
   return kitchen
 
 
-def provisioner(role_under_test):
-  kitchen = {
-    'provisioner': {
-      'extra_vars': {
-        'role_under_test': role_under_test,
-      }
-    }
-  }
-  return kitchen
-
-
 def get_role_under_test(role_under_test):
   if role_under_test:
     return role_under_test
@@ -102,7 +91,6 @@ def main():
   kitchen = {}
   kitchen.update(suites(ansible_versions))
   kitchen.update(platforms(os_versions))
-  kitchen.update(provisioner(role_under_test))
 
   kitchen_filename = os.path.join(
       os.path.dirname(__file__), '.kitchen.local.yml')

--- a/write_kitchen_playbook.py
+++ b/write_kitchen_playbook.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# coding=utf-8
+# Copyright (C) 2017 Wesley Tanaka <http://wtanaka.com/>
+"""Output a yml structure suitable for overwriting
+kitchen-playbook.yml
+"""
+
+import optparse
+import os
+import os.path
+
+from atomicwrites import atomic_write
+import yaml
+
+
+def get_role_under_test(role_under_test):
+  if role_under_test:
+    return role_under_test
+
+  role_under_test = os.environ.get('ROLE_UNDER_TEST', None)
+  if role_under_test:
+    return role_under_test
+
+  role_under_test = os.path.basename(
+      os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+  return role_under_test
+
+
+def main():
+  parser = optparse.OptionParser()
+  parser.add_option("-r", "--role-under-test",
+      dest="role_under_test",
+      help="Name of role directory. "
+      "Falls back to ROLE_UNDER_TEST environment, "
+      "then to the name of this file's parent directory. "
+      " (e.g. 'ansible-role-python-numpy')")
+  (options, args) = parser.parse_args()
+
+  role_under_test = get_role_under_test(options.role_under_test)
+
+  playbook = []
+  playbook.append({'include': 'playbook-compat.yml'})
+  playbook.append({
+      'hosts': 'all',
+      'roles': [
+          {
+            'role': role_under_test,
+            'is_integration_test': True,
+          },
+      ]
+  })
+
+  playbook_filename = os.path.join(
+      os.path.dirname(__file__), 'kitchen-playbook.yml')
+  # Work around issue in atomic_write where if
+  # os.path.dirname(__file__) == '' then we get OSError: [Errno 2] No
+  # such file or directory: ''
+  playbook_filename = os.path.abspath(playbook_filename)
+  with atomic_write(playbook_filename, overwrite=True) as fp:
+    yaml.dump(playbook, fp)
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
This attempts to support for Ansible 1.2 and Ansible 1.3, but did not
work due to kitchen-ansiblepush using a dynamic inventory script which
is a feature introduced in Ansible 1.4

Hardcoding the role name in the playbook makes it easier to run ad-hoc
commands after the initial role-tester-ansible download